### PR TITLE
stories-folder should start with a dot

### DIFF
--- a/configs/mantra-js.yaml
+++ b/configs/mantra-js.yaml
@@ -8,7 +8,7 @@ panes:
             template: actionIndex
       - directory: components
         structure:
-          - file: stories/index.js
+          - file: .stories/index.js
             template: storiesIndex
       - directory: containers
       - file: routes.js
@@ -115,7 +115,7 @@ templates:
             });
           });
       - type: create
-        path: stories/$name_stories.js
+        path: .stories/$name_stories.js
         text: |
           import React from 'react';
           import { storiesOf, action } from '@kadira/storybook';
@@ -128,7 +128,7 @@ templates:
               );
             })
       - type: replace
-        path: stories/index.js
+        path: .stories/index.js
         what: // imports
         replace: |
           // imports

--- a/configs/mantra-ts.yaml
+++ b/configs/mantra-ts.yaml
@@ -8,7 +8,7 @@ panes:
             template: actionIndex
       - directory: components
         structure:
-          - file: stories/index.ts
+          - file: .stories/index.ts
             template: storiesIndex
       - directory: containers
       - file: routes.tsx
@@ -120,7 +120,7 @@ templates:
             });
           });
       - type: create
-        path: stories/$name_stories.ts
+        path: .stories/$name_stories.ts
         text: |
           import React from 'react';
           import { storiesOf, action } from '@kadira/storybook';
@@ -133,7 +133,7 @@ templates:
               );
             })
       - type: replace
-        path: stories/index.ts
+        path: .stories/index.ts
         what: // imports
         replace: |
           // imports


### PR DESCRIPTION
Official mantra sample app uses .stories as directory names with dot to prevent meteor from evaluating it automatically.

Maybe we should also switch to .stories
